### PR TITLE
Specify output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,10 @@ To run the script recursively (i.e. including any subdirectories containing TIFF
 
     python tiffs_to_pdf.py <path_to_root_folder> -r
     
-When run recursively, the script will identify any folders containing TIFF files and create a PDF one directory above the TIFFs themselves. The PDF file will be named according to the folder containing the TIFFs. If that folder is named "TIFF", "TIFFs", "Master", or "Masters", the PDF will be given the name of that folder's parent folder, in an attempt to capture the object name for the PDF. Additional "generic" folder names to be ignored can be added to the "genericTest" list on line 69.
+When run recursively, the script will identify any folders containing TIFF files and create a PDF one directory above the TIFFs themselves. The PDF file will be named according to the folder containing the TIFFs. If that folder is named "TIFF", "TIFFs", "Master", or "Masters", the PDF will be given the name of that folder's parent folder, in an attempt to capture the object name for the PDF. Additional "generic" folder names to be ignored can be added to the "genericTest" list on line 91.
+
+To specify a custom PDF output directory, use the <code>-r --output</code> switch and provide the path to a directory:
+
+	python tiffs_to_pdf.py <path_to_directory> -o <path_to_output_directory>
+	
+The output switch can be used with or without the recursive switch.

--- a/tiffs_to_pdf.py
+++ b/tiffs_to_pdf.py
@@ -10,6 +10,7 @@ parser = argparse.ArgumentParser(description='Compile all TIFFs in a directory i
 
 parser.add_argument('directory', help="directory containing tiffs to be converted to pdf", action="store", nargs='?', default=os.getcwd())
 parser.add_argument('-r', '--recursive', help="recursively create pdfs in all subdirectories containing tiffs", action="store_true", dest="r", required=False)
+parser.add_argument('-o', '--output', help="specify an output directory for all created PDFs", action="store", dest="o", required=False)
 
 args = parser.parse_args()
 
@@ -51,7 +52,11 @@ if not args.r:
     folderPath = args.directory
     folderPath = folderPath.replace('\\', '/')
     folderName = folderPath.split('/')[-1]
-    pdfPath = os.path.join(folderPath,folderName + '.pdf')
+    pdfName = folderName + '.pdf'
+    if args.o:
+        pdfPath = os.path.join(args.o, pdfName)
+    else:
+        pdfPath = os.path.join(folderPath, pdfName)
     pdfPath = pdfPath.replace('\\', '/')
     fileList = os.listdir(folderPath)
     pageNum = 0
@@ -82,13 +87,16 @@ elif args.r:
     for folder in tiffFolders:
         print('TIFFs found in ' + folder)
         tiffsList = []
-        pdfName = folder.split('/')[-1]
+        pdfName = folder.split('/')[-1] + '.pdf'
         genericTest = re.match('tiffs|tiff|master|masters', pdfName.lower())
         if genericTest:
-            folderName = pdfName
-            pdfName = folder.split('/')[-2]
-            print('"' + folderName + '" is a generic folder name. PDF will be named "' + pdfName + '.pdf"')
-        pdfPath = os.path.join(folder,pdfName + '.pdf')
+            folderName = folder.split('/')[-1]
+            pdfName = folder.split('/')[-2] + '.pdf'
+            print('"' + folderName + '" is a generic folder name. PDF will be named "' + pdfName)
+        if args.o:
+            pdfPath = os.path.join(args.o, pdfName)
+        else:
+            pdfPath = os.path.join(folder, pdfName)
         pdfPath = pdfPath.replace('\\', '/')
         fileList = os.listdir(folder)
         pageNum = 0


### PR DESCRIPTION
Allow users to specify output directory for PDFs with -o switch, and correct genericTest line number in readme